### PR TITLE
feat: add button to display favorites

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -5,6 +5,7 @@ import Scrollbar from "../Scrollbar/Scrollbar";
 import { MAX_UUID } from "../../../lib/constants";
 import UUIDDisplay from "../UUIDDisplay/UUIDDisplay";
 import SearchWidget from "../SearchWidget/SearchWidget";
+import FavoritesWidget from "../FavoritesWidget";
 import { indexToUUID } from "../../../lib/uuidTools";
 
 const Wrapper = styled.div`
@@ -41,6 +42,7 @@ function App() {
   const [itemsToShow, setItemsToShow] = React.useState(40);
   const [search, setSearch] = React.useState("");
   const [searchDisplayed, setSearchDisplayed] = React.useState(false);
+  const [showFavorites, setShowFavorites] = React.useState(false);
   const animationRef = React.useRef(null);
 
   const [favedUUIDs, setFavedUUIDs] = React.useState(
@@ -117,6 +119,12 @@ function App() {
   }, [isAnimating, targetPosition]);
 
   const displayedUUIDs = React.useMemo(() => {
+    if (showFavorites) {
+      return Object.keys(favedUUIDs).map((uuid, i) => ({
+        index: BigInt(i),
+        uuid,
+      }));
+    }
     return Array.from({ length: itemsToShow }, (_, i) => {
       const index = virtualPosition + BigInt(i);
       if (index < 0n) {
@@ -132,7 +140,7 @@ function App() {
       }
       return { index, uuid };
     });
-  }, [virtualPosition, itemsToShow]);
+  }, [virtualPosition, itemsToShow, showFavorites, favedUUIDs]);
 
   return (
     <>
@@ -146,6 +154,10 @@ function App() {
         setSearchDisplayed={setSearchDisplayed}
         displayedUUIDs={displayedUUIDs}
         MAX_POSITION={MAX_POSITION}
+      />
+      <FavoritesWidget
+        setShowFavorites={setShowFavorites}
+        isShowingFavorites={showFavorites}
       />
       <Wrapper>
         <HeaderAndContent>

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -6,7 +6,7 @@ import { MAX_UUID } from "../../../lib/constants";
 import UUIDDisplay from "../UUIDDisplay/UUIDDisplay";
 import SearchWidget from "../SearchWidget/SearchWidget";
 import FavoritesWidget from "../FavoritesWidget";
-import { indexToUUID } from "../../../lib/uuidTools";
+import { indexToUUID, uuidToIndex } from "../../../lib/uuidTools";
 
 const Wrapper = styled.div`
   display: flex;
@@ -121,7 +121,7 @@ function App() {
   const displayedUUIDs = React.useMemo(() => {
     if (showFavorites) {
       return Object.keys(favedUUIDs).map((uuid, i) => ({
-        index: BigInt(i),
+        index: uuidToIndex(uuid),
         uuid,
       }));
     }

--- a/src/components/FavoritesWidget/FavoritesWidget.js
+++ b/src/components/FavoritesWidget/FavoritesWidget.js
@@ -1,0 +1,60 @@
+import React from "react";
+import styled from "styled-components";
+import UnstyledButton from "../UnstyledButton/UnstyledButton";
+import { Star } from "../Icons";
+import { querySmallScreen, SCROLLBAR_WIDTH } from "../../../lib/constants";
+
+const FavoritesButton = styled(UnstyledButton)`
+  background-color: var(--slate-50);
+  border-radius: 0 0 8px 8px;
+  font-size: 0.875rem;
+  font-family: monospace;
+  padding: .15rem 1rem;
+  width: 3rem;
+  display: flex;
+  align-items: center;
+  position: absolute;
+  z-index: 999;
+  right: 16rem;
+  color: inherit;
+
+  --fill-color: ${(props) =>
+    props.$isShowingFavorites ? "var(--yellow-500)" : "transparent"};
+
+  @media ${querySmallScreen} {
+    right: 8rem;
+    bottom: 0;
+    border-radius: 8px 8px 0 0;
+  }
+  outline: none;
+  &:focus {
+    outline: none;
+  }
+  cursor: pointer;
+  transition: background-color 0.1s ease-in-out;
+  @media (hover: hover) {
+    &:hover {
+      background-color: var(--slate-400);
+    }
+  }
+`;
+
+function FavoritesWidget({ setShowFavorites, isShowingFavorites }) {
+  return (
+    <>
+      <FavoritesButton
+        onClick={() => {
+          setShowFavorites((prev) => !prev);
+        }}
+        $isShowingFavorites={isShowingFavorites}
+      >
+        <Star
+          fill="var(--fill-color)"
+          style={{ height: "100%", aspectRatio: 1 }}
+        />
+      </FavoritesButton>
+    </>
+  );
+}
+
+export default FavoritesWidget;

--- a/src/components/FavoritesWidget/index.js
+++ b/src/components/FavoritesWidget/index.js
@@ -1,0 +1,2 @@
+export * from './FavoritesWidget';
+export { default } from './FavoritesWidget';

--- a/src/components/Scrollbar/Scrollbar.js
+++ b/src/components/Scrollbar/Scrollbar.js
@@ -101,7 +101,11 @@ function Scrollbar({
   }, [MAX_POSITION]);
   const atBottom = virtualPosition > bottomThreshold;
 
-  const scrollPercentage = Number((virtualPosition * 100n) / MAX_POSITION);
+  const scrollPercentage = React.useMemo(() => {
+    if (MAX_POSITION === 0n) return 0;
+    return Number((virtualPosition * 100n) / MAX_POSITION);
+  }, [virtualPosition, MAX_POSITION]);
+
   const thumbPosition = Math.min(
     100 - (THUMB_HEIGHT * 100) / (trackRef.current?.clientHeight || 100),
     Math.max(0, scrollPercentage)


### PR DESCRIPTION
**Problem:** I have a number of favorite UUIDs saved, but it's quite difficult to find them in the scrolling list again when I want to go back and revisit!

**Solution:** A toggle to show a list of my favorited UUIDs.

![every-uuid-short](https://github.com/user-attachments/assets/6522e52f-6d1f-4a95-b739-bf13d44b13f9)


**Known issues:** 
~* The index of the UUIDs are not correct corresponding to their original value in the list. I'm not sure how to achieve this aside from also saving that index to the localStorage object.~ Fixed!