### PR TITLE
Full UUID search

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": "react-app"
+  "extends": "react-app",
+  "globals":{
+    "BigInt": true
+  }
 }

--- a/hooks/use-uuid-search.js
+++ b/hooks/use-uuid-search.js
@@ -1,305 +1,40 @@
 import React from "react";
-import { uuidToIndex, indexToUUID } from "../lib/uuidTools";
-import { MAX_UUID } from "../lib/constants";
-const PADDING_SENTINEL = "X";
-const VARIANT_SENTINEL = "V";
-const VERSION = "4";
-const VALID_VARIANTS = ["8", "9", "a", "b"];
-
-function getPatternWithPadding(search, leftPadding) {
-  const uuidTemplate = `${PADDING_SENTINEL.repeat(8)}-${PADDING_SENTINEL.repeat(4)}-${VERSION}${PADDING_SENTINEL.repeat(3)}-${VARIANT_SENTINEL}${PADDING_SENTINEL.repeat(3)}-${PADDING_SENTINEL.repeat(12)}`;
-
-  for (let pos = 0; pos < search.length; pos++) {
-    const patternPos = leftPadding + pos;
-    const inputChar = search[pos];
-    const templateChar = uuidTemplate[patternPos];
-
-    if (
-      (inputChar === "-" && templateChar !== "-") ||
-      (templateChar === "-" && inputChar !== "-")
-    ) {
-      return null;
-    }
-
-    if (patternPos === 14 && inputChar !== VERSION) {
-      return null;
-    }
-
-    if (patternPos === 19 && !VALID_VARIANTS.includes(inputChar)) {
-      return null;
-    }
-  }
-
-  const pattern =
-    uuidTemplate.slice(0, leftPadding) +
-    search +
-    uuidTemplate.slice(leftPadding + search.length);
-
-  const sections = pattern.split("-");
-  if (
-    sections[0].length === 8 &&
-    sections[1].length === 4 &&
-    sections[2].length === 4 &&
-    sections[3].length === 4 &&
-    sections[4].length === 12
-  ) {
-    return pattern;
-  }
-
-  return null;
-}
-
-function getAllValidPatterns(search) {
-  const patterns = [];
-  const uuidTemplate = `${PADDING_SENTINEL.repeat(8)}-${PADDING_SENTINEL.repeat(4)}-${VERSION}${PADDING_SENTINEL.repeat(3)}-${VARIANT_SENTINEL}${PADDING_SENTINEL.repeat(3)}-${PADDING_SENTINEL.repeat(12)}`;
-
-  for (
-    let leftPadding = 0;
-    leftPadding < uuidTemplate.length - search.length + 1;
-    leftPadding++
-  ) {
-    const pattern = getPatternWithPadding(search, leftPadding);
-    if (pattern) {
-      patterns.push({ pattern, leftPadding });
-    }
-  }
-
-  return patterns;
-}
-
-function generateRandomUUID(pattern) {
-  return pattern
-    .replace(
-      new RegExp(VARIANT_SENTINEL, "g"),
-      () => VALID_VARIANTS[Math.floor(Math.random() * VALID_VARIANTS.length)]
-    )
-    .replace(
-      new RegExp(PADDING_SENTINEL, "g"),
-      () => "0123456789abcdef"[Math.floor(Math.random() * 16)]
-    );
-}
-
-const SEARCH_LOOKBACK = 50;
-const SEARCH_LOOKAHEAD = 25;
-const RANDOM_SEARCH_ITERATIONS = 100;
+import { findNextIndex } from "../lib/uuidTools";
 
 export function useUUIDSearch({ virtualPosition, displayedUUIDs }) {
   const [search, setSearch] = React.useState(null);
-  const [uuid, setUUID] = React.useState(null);
-  // Stack of complete states we've seen
-  const [nextStates, setNextStates] = React.useState([]);
-
-  const previousUUIDs = React.useMemo(() => {
-    let hasComputed = false;
-    let value = null;
-    const getValue = () => {
-      const compute = () => {
-        const prev = [];
-        for (let i = 1; i <= SEARCH_LOOKBACK; i++) {
-          i = BigInt(i);
-          let index = BigInt(virtualPosition) - i;
-          if (index < 0n) {
-            index = MAX_UUID + index;
-          }
-          const uuid = indexToUUID(index);
-          prev.push({ index, uuid });
-        }
-        return prev;
-      };
-      if (!hasComputed) {
-        value = compute();
-        hasComputed = true;
-      }
-      return value;
-    };
-    return getValue;
-  }, [virtualPosition]);
-
-  const nextUUIDs = React.useMemo(() => {
-    let hasComputed = false;
-    let value = null;
-    const getValue = () => {
-      const compute = () => {
-        const next = [];
-        for (let i = 1; i <= SEARCH_LOOKAHEAD; i++) {
-          i = BigInt(i);
-          let index = virtualPosition + i;
-          if (index > MAX_UUID) {
-            index = index - MAX_UUID;
-          }
-          const uuid = indexToUUID(index);
-          next.push({ index, uuid });
-        }
-        return next;
-      };
-      if (!hasComputed) {
-        value = compute();
-        hasComputed = true;
-      }
-      return value;
-    };
-    return getValue;
-  }, [virtualPosition]);
-
-  const searchAround = React.useCallback(
-    ({ input, wantHigher, canUseCurrentIndex }) => {
-      if (wantHigher) {
-        const startPosition = canUseCurrentIndex ? 0 : 1;
-        for (let i = startPosition; i < displayedUUIDs.length; i++) {
-          const uuid = displayedUUIDs[i].uuid;
-          if (uuid.includes(input)) {
-            return { uuid, index: displayedUUIDs[i].index };
-          }
-        }
-        const next = nextUUIDs();
-        for (let i = 0; i < next.length; i++) {
-          const uuid = next[i].uuid;
-          if (uuid.includes(input)) {
-            return { uuid, index: nextUUIDs[i].index };
-          }
-        }
-      } else {
-        // canUseCurrentIndex isn't relevant when searching backwards!
-        const prev = previousUUIDs();
-        for (const { uuid, index } of prev) {
-          if (uuid.includes(input)) {
-            return { uuid, index };
-          }
-        }
-      }
-      return null;
-    },
-    [displayedUUIDs, previousUUIDs, nextUUIDs]
-  );
-
-  const searchRandomly = React.useCallback(
-    ({ input, wantHigher }) => {
-      const patterns = getAllValidPatterns(input);
-      if (patterns.length === 0) return null;
-      let best = null;
-      let compareIndex = virtualPosition;
-      for (let i = 0; i < RANDOM_SEARCH_ITERATIONS; i++) {
-        const { pattern, leftPadding } =
-          patterns[Math.floor(Math.random() * patterns.length)];
-        const uuid = generateRandomUUID(pattern);
-        const index = uuidToIndex(uuid);
-        const satisfiesConstraint = wantHigher
-          ? index > compareIndex
-          : index < compareIndex;
-        const notInHistory = !nextStates.some(
-          ({ uuid: nextUUID }) => nextUUID === uuid
-        );
-        if (satisfiesConstraint && notInHistory) {
-          const isBetter =
-            best === null
-              ? true
-              : wantHigher
-                ? index < best.index
-                : index > best.index;
-          if (isBetter) {
-            best = { uuid, pattern, leftPadding, index };
-          }
-        }
-      }
-      if (best) {
-        return best;
-      }
-      const { pattern: fallbackPattern, leftPadding: fallbackLeftPadding } =
-        patterns[Math.floor(Math.random() * patterns.length)];
-      return {
-        uuid: generateRandomUUID(fallbackPattern),
-        pattern: fallbackPattern,
-        leftPadding: fallbackLeftPadding,
-        index: uuidToIndex(uuid),
-      };
-    },
-    [nextStates, uuid, virtualPosition]
-  );
+  const [index, setIndex] = React.useState(null);
 
   const searchUUID = React.useCallback(
     (input) => {
-      const invalid = input.toLowerCase().replace(/[^0-9a-f-]/g, "");
-      if (invalid !== input) {
-        return null;
-      }
-      const newSearch = input.toLowerCase().replace(/[^0-9a-f-]/g, "");
-      if (!newSearch) return null;
+      setSearch(input);
 
-      // Clear next states stack when search changes
-      setNextStates([]);
-
-      const inner = () => {
-        const around = searchAround({
-          input,
-          wantHigher: true,
-          canUseCurrentIndex: true,
-        });
-        if (around) return around;
-        return searchRandomly({ input, wantHigher: true });
-      };
-
-      const result = inner();
-      if (result) {
-        setSearch(newSearch);
-        setUUID(result.uuid);
-        setNextStates((prev) => [...prev, result]);
-      }
-      return result?.uuid ?? null;
+      const index = findNextIndex(input, virtualPosition, 1n);
+      if (index) setIndex(index);
     },
-    [searchAround, searchRandomly]
+    [virtualPosition],
   );
 
   const nextUUID = React.useCallback(() => {
-    if (!uuid || !search) return null;
-    const inner = () => {
-      const around = searchAround({
-        input: search,
-        wantHigher: true,
-        canUseCurrentIndex: false,
-      });
-      if (around) return around;
-      return searchRandomly({ input: search, wantHigher: true });
-    };
-    const result = inner();
-    if (result) {
-      setUUID(result.uuid);
-      setNextStates((prev) => [...prev, result]);
-      return result.uuid;
-    }
+    if (!search) return null;
+
+    const index = findNextIndex(search, virtualPosition, 1n);
+    if (index) setIndex(index);
     return null;
-  }, [uuid, search, searchAround, searchRandomly]);
+  }, [search, virtualPosition]);
 
   const previousUUID = React.useCallback(() => {
-    if (!uuid || !search) return null;
+    if (!search) return null;
 
-    if (nextStates.length > 1) {
-      setNextStates((prev) => prev.slice(0, -1));
-      const prevState = nextStates[nextStates.length - 2];
-      setUUID(prevState.uuid);
-      return prevState.uuid;
-    }
-
-    const inner = () => {
-      const around = searchAround({
-        input: search,
-        wantHigher: false,
-        canUseCurrentIndex: false,
-      });
-      if (around) return around;
-      return searchRandomly({ input: search, wantHigher: false });
-    };
-    const result = inner();
-    if (result) {
-      setUUID(result.uuid);
-      return result.uuid;
-    }
+    const index = findNextIndex(search, virtualPosition, -1n);
+    if (index) setIndex(index);
     return null;
-  }, [uuid, search, nextStates, searchAround, searchRandomly]);
+  }, [search, virtualPosition]);
 
   return {
     searchUUID,
     nextUUID,
     previousUUID,
-    currentUUID: uuid,
+    currentIndex: index,
   };
 }

--- a/lib/uuidTools.js
+++ b/lib/uuidTools.js
@@ -16,7 +16,7 @@ class RandomBytes {
     this.seed = seed
   }
   next(bytes) {
-    const output = randomBytesSeed(16, this.seed);
+    const output = randomBytesSeed(bytes, this.seed);
     this.seed = output;
     return output;
   }

--- a/lib/uuidTools.js
+++ b/lib/uuidTools.js
@@ -191,7 +191,7 @@ function maskIndex(index, bit) {
 
 /**
  * Finds a query by searching through consecutive indexes.
- * This is very fast for queries <= 3 characters.
+ * This is very fast for queries <= 2 characters.
  */
 function nextIndexBruteForce(query, index, direction) {
   while(true) {
@@ -427,7 +427,7 @@ export function findNextIndex(query, startIndex, direction) {
 
   if (validPatterns.length === 0) return undefined;
 
-  if (query.length <= 3) {
+  if (query.length <= 2) {
     return nextIndexBruteForce(query, startIndex, direction);
   }
 

--- a/lib/uuidTools.js
+++ b/lib/uuidTools.js
@@ -1,3 +1,437 @@
+import randomBytesSeed from '@csquare/random-bytes-seed';
+
+const UUID_ENTROPY = 122n;
+const UUID_COUNT = 1n << UUID_ENTROPY;
+const BIT_MASK_FULL = UUID_COUNT - 1n;
+const INDEX_OFFSET = 1237834238432n; // Random offest
+
+/** Inverts a matrix, assumes it is invertible */
+function invertMatrix(matrix) {
+  const identity = Array(matrix.length).fill(0).map((_, i) => 1n << BigInt(i))
+  const adjointMatrix = matrix.map((row, i) => ({ original: row, inverse: identity[i] }))
+
+  for (let index = 0n; index < BigInt(adjointMatrix.length); index++) {
+    // Find the row where the column bit is 1
+    let rowIndex = undefined;
+    for (let i = index; i < BigInt(adjointMatrix.length); i++) {
+      if (((adjointMatrix[i].original >> index) & 1n) === 1n) {
+        rowIndex = i;
+        break;
+      }
+    }
+
+    // Swap rowIndex with row
+    const tempRow = adjointMatrix[index];
+    adjointMatrix[index] = adjointMatrix[rowIndex];
+    adjointMatrix[rowIndex] = tempRow;
+
+    // Eliminate column from rows below
+    for (let i = index + 1n; i < BigInt(adjointMatrix.length); i++) {
+      if (((adjointMatrix[i].original >> index) & 1n) === 1n) {
+        adjointMatrix[i].original ^= adjointMatrix[index].original;
+        adjointMatrix[i].inverse ^= adjointMatrix[index].inverse;
+      }
+    }
+  }
+
+  // Eliminate column from rows above
+  for (let index = BigInt(adjointMatrix.length) - 1n; index >= 0n; index--) {
+    for (let i = index - 1n; i >= 0n; i--) {
+      if (((adjointMatrix[i].original >> index) & 1n) === 1n) {
+        adjointMatrix[i].original ^= adjointMatrix[index].original;
+        adjointMatrix[i].inverse ^= adjointMatrix[index].inverse;
+      }
+    }
+  }
+
+  return adjointMatrix.map((value) => value.inverse);
+}
+
+/** Modulo operation avoiding JS's weird behaviour with negative numbers */
+function modulo(value, modulus) {
+  return value & (modulus - 1n);
+}
+
+/** Returns the rank of a matrix on GF(2) using Gaussian elimination */
+function rank(matrix) {
+  matrix = matrix.filter((row) => row > 0n)
+  if (matrix.length === 0) return 0;
+
+  const targetRow = matrix.find((row) => (row & 1n) === 1n);
+
+  if (targetRow === undefined) {
+    return rank(matrix.map((row) => row >> 1n))
+  }
+
+  return 1 + rank(
+    matrix.map((row) => (row & 1n) > 0n ? (row ^ targetRow) >> 1n : row >> 1n)
+  );
+}
+
+/** Returns if a matrix is full rank on GF(2) using gaussian elimination */
+function isFullRank(matrix) {
+  return rank(matrix) === matrix.length;
+}
+
+/** Wrapper for seeded random bytes */
+class RandomBytes {
+  constructor(seed) {
+    this.seed = seed
+  }
+  next(bytes) {
+    const output = randomBytesSeed(16, this.seed);
+    this.seed = output;
+    return output;
+  }
+}
+
+/** Returns a BigInt constructed from a Buffer of bytes */
+function bytesToBigInt(bytes) {
+  return BigInt(
+    '0x' + Array.from(bytes)
+      .map((byte) => byte.toString(16).padStart(2, 0))
+      .join('')
+  );
+}
+
+/** Creates a random invertible matrix on GF(2) */
+function randomInvertibleMatrix(size, randomGenerator) {
+  let matrix
+  while (true) {
+    matrix = Array(size)
+      .fill(0)
+      .map((value) => {
+        return bytesToBigInt(randomGenerator.next(16)) & BIT_MASK_FULL;
+      })
+
+    if (isFullRank(matrix)) return matrix
+  }
+}
+
+const ENCRYPT_MATRIX = randomInvertibleMatrix(122, new RandomBytes('42'));
+const INVERSE_ENCRYPT_MATRIX = invertMatrix(ENCRYPT_MATRIX);
+
+/** Returns the count of the non-zero bits in a BigInt */
+function countBits(value) {
+  let count = 0n;
+  while (value > 0n) {
+    count += value & 1n;
+    value = value >> 1n;
+  }
+  return count;
+}
+
+/** Encrypts an index to a UUID based on an encryption matrix */
+function encrypt(value, matrix) {
+  let encrypted = 0n
+  for (let i = 0n; i < UUID_ENTROPY; i++) {
+    encrypted = encrypted | ((countBits(matrix[i] & value) % 2n) << i)
+  }
+  return encrypted
+}
+
+
+/** Returns a string representation of a UUID value */
+function uuidToString(value) {
+  const result = (
+    ((value >> 74n) << 80n) |
+    (4n << 76n) |
+    (((value >> 62n) & (1n << 12n) - 1n) << 64n) |
+    (2n << 62n) |
+    (value & (1n << 62n) - 1n)
+  );
+
+  const hex = result.toString(16).padStart(32, 0);
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+/** Offets an index to avoid the first UUID being 0 */
+function offsetIndex(index, offset) {
+  return modulo(index + offset, UUID_COUNT);
+}
+
+/** Returns a UUID string from an index */
+function uuidFromIndex(index) {
+  return uuidToString(encrypt(offsetIndex(index, INDEX_OFFSET), ENCRYPT_MATRIX));
+}
+
+/** Compares two values and returns if they are greater/lesser/equal */
+function compareValues(x, y) {
+  if (x === y) return 0;
+  return x > y ? 1n : -1n;
+}
+
+/** Returns the distance between two values in a direction (1 or -1) */
+function directionDistance(a, b, direction) {
+  return modulo((b - a) * direction, UUID_COUNT);
+}
+
+/**
+ * Masks bits up to an index
+ * For example `maskIndex(0b1111n, 1n) === 0b1100n`
+ * (The 0th and 1st bits are masked off)
+ */
+function maskIndex(index, bit) {
+  return (index >> (bit + 1n)) << (bit + 1n);
+}
+
+/**
+ * Finds a query by searching through consecutive indexes.
+ * This is very fast for queries <= 3 characters.
+ */
+function nextIndexBruteForce(query, index, direction) {
+  while(true) {
+    index = modulo(index + direction, UUID_COUNT)
+    if (uuidFromIndex(index).includes(query))  {
+      return index
+    }
+  }
+}
+
+/**
+ * Takes a hex character or asterisk
+ *   - For a hex character returns a list of bits LSB first
+ *   - For an asterisk returns a list of None (indicating unknown bits)
+ */
+function hexToBits(character) {
+  if (character === '*') return [undefined, undefined, undefined, undefined]
+  const value = BigInt('0x' + character);
+  const bits = [];
+  for (let i = 0n; i < 4n; i++) {
+    bits.push((value >> i) & 1n);
+  }
+  return bits;
+}
+
+const HEX = '[0-9a-f*]';
+const UUID_REGEX = new RegExp(`^${HEX}{8}-${HEX}{4}-[4*]${HEX}{3}-[89ab*]${HEX}{3}-${HEX}{12}$`);
+const DELIMITER_INDEXES = [8, 13, 18, 23];
+
+/** Returns if a UUID pattern is valid */
+function patternIsValid(pattern) {
+  if (pattern.length !== 36) return false;
+  return Boolean(pattern.match(UUID_REGEX));
+}
+
+/** Replace a character in a string */
+function replaceCharacter(value, index, character) {
+  return value.slice(0, index) + character + value.slice(index + 1);
+}
+
+/** Returns a UUID pattern with asterisks replaced with hyphens appropriately */
+function maskHyphens(pattern) {
+  DELIMITER_INDEXES.forEach((index) => {
+    if (pattern[index] === '*') pattern = replaceCharacter(pattern, index, '-');
+  })
+  return pattern;
+}
+
+/**
+ * Takes a valid UUID pattern and returns an LSB first list of bits,
+ * excluding fixed bits, where unknown bits '*' are undefined.
+ */
+function patternToBits(pattern) {
+  const patternBits = Array.from(pattern.replace(/-/g, '')).reverse().map(hexToBits).flat(1);
+  return patternBits.slice(0, 62).concat(patternBits.slice(64, 76)).concat(patternBits.slice(80))
+}
+
+/**
+ * Takes an array of solutions and returns the one which is closest to startIndex in direction
+ */
+function findBestSolution(solutions, startIndex, direction) {
+  let minDistance = Infinity;
+  let chosenIndex;
+
+  for (let i = 0; i < solutions.length; i++) {
+    const distance = directionDistance(startIndex, solutions[i], direction);
+    if (distance < minDistance) {
+      minDistance = distance;
+      chosenIndex = i;
+    }
+  }
+
+  return solutions[chosenIndex];
+}
+
+/** Converts an adjoint matrix to row echelon form */
+function toRowEchelonForm(adjointMatrix) {
+  let row = 0n;
+  let column = 0n;
+
+  while (row < BigInt(adjointMatrix.length)) {
+    // Find a row where the column bit is 1
+    let rowIndex = undefined;
+    let nonZero = false;
+    for (let i = row; i < BigInt(adjointMatrix.length); i++) {
+      if (adjointMatrix[i].row > 0n) {
+        nonZero = true;
+      }
+      if (((adjointMatrix[i].row >> column) & 1n) === 1n) {
+        rowIndex = i;
+        break;
+      }
+    }
+    if (rowIndex === undefined) {
+      if (nonZero) {
+        column += 1n;
+        continue;
+      }
+      while (row < BigInt(adjointMatrix.length)) {
+        adjointMatrix.pop();
+      }
+      return;
+    }
+
+    // Swap rowIndex with row
+    const tempRow = adjointMatrix[row];
+    adjointMatrix[row] = adjointMatrix[rowIndex];
+    adjointMatrix[rowIndex] = tempRow;
+
+    // Eliminate column from rows below
+    for (let i = row + 1n; i < BigInt(adjointMatrix.length); i++) {
+      if (((adjointMatrix[i].row >> column) & 1n) > 0n) {
+        adjointMatrix[i].row ^= adjointMatrix[row].row;
+        adjointMatrix[i].bit ^= adjointMatrix[row].bit;
+      }
+    }
+
+    row += 1n;
+    column += 1n;
+  }
+}
+
+/**
+ * Back substitutes a value into the adjoint matrix
+ */
+function backSubstitute(adjointMatrix, column, value) {
+  const solutionBitMask = 1n << column;
+  for (let i = 0; i < adjointMatrix.length; i++) {
+    if ((adjointMatrix[i].row & solutionBitMask) > 0) {
+      adjointMatrix[i].row %= solutionBitMask;
+      adjointMatrix[i].bit ^= value;
+    }
+  }
+}
+
+
+/**
+ * Finds the index for the next uuid which matches the known bits supplied in the specified direction.
+ *
+ * @param adjointMatrix Matrix rows corresponding paired with known bits of the UUID.
+ *                      Matrix must be in row echelon form without trailing zero rows.
+ * @param startIndex The index of the point to start searching from.
+ * @param currentBitIndex The index of the current bit to be computed.
+ * @param direction The direction to search in: 1 or -1.
+ */
+function nextIndexFromAdjoint(adjointMatrix, startIndex, currentBitIndex, direction) {
+  // Find the solution from MSB to LSB
+  let solution = 0n;
+  for (let i = currentBitIndex; i >= 0n; i--) {
+    const solutionBitMask = 1n << i;
+    let bit;
+
+    // If the last row of the matrix is a single bit in i, this determines a bit of the solution
+    if (adjointMatrix.length > 0 && adjointMatrix[adjointMatrix.length - 1].row === solutionBitMask) {
+      bit = adjointMatrix.pop().bit;
+    }
+
+    // Otherwise the bit is not determined, so we can pick intelligently or guess
+
+    // We check if the solution has diverged from the startIndex,
+    // if so then we want to pick the lowest/highest value (depending on the direction)
+    // to minmise the difference between this solution and the startIndex.
+    else if (maskIndex(startIndex, i) !== solution) {
+      bit = direction === 1n ? 0n : 1n;
+    }
+
+    // Otherwise we have no idea what next bit is,
+    // so we guess the next bit from the startIndex,
+    // recurse into the solver, and check if we were correct
+    else {
+      bit = (startIndex >> i) & 1n;
+
+      // Copy the adjoint matrix, since we may backtrack out of this
+      const adjointMatrixCopy = adjointMatrix.map(({ row, bit }) => ({ row, bit }));
+      backSubstitute(adjointMatrixCopy, i, bit);
+
+      const potentialSolution = nextIndexFromAdjoint(adjointMatrixCopy, startIndex % solutionBitMask, i - 1n, direction);
+
+      if (compareValues(potentialSolution, startIndex % solutionBitMask) === direction) {
+        return potentialSolution | ((startIndex >> i) << i);
+      }
+
+      // Otherwise we guessed wrong
+      bit ^= 1n
+    }
+
+    // Back substitute value into matrix and update the solution
+    backSubstitute(adjointMatrix, i, bit);
+    if (bit === 1n) solution |= solutionBitMask;
+  }
+
+  return solution;
+}
+
+
+
+/** Returns the adjoint matrix only for rows with known bits */
+function getKnownAdjointMatrix(matrix, vector) {
+  return matrix.map((row, i) => ({ row, bit: vector[i] })).filter(({ bit }) => bit !== undefined);
+}
+
+/**
+ * Returns the index for the next UUID which matches
+ * the pattern of bits supplied in the specified direction.
+ * Offsets the index before and after solving to avoid the first UUID being 0
+ */
+function nextIndexForPattern(patternBits, startIndex, direction) {
+  const adjointMatrix = getKnownAdjointMatrix(ENCRYPT_MATRIX, patternBits);
+  toRowEchelonForm(adjointMatrix);
+
+  return offsetIndex(
+    nextIndexFromAdjoint(
+      adjointMatrix,
+      offsetIndex(startIndex, INDEX_OFFSET),
+      UUID_ENTROPY - 1n,
+      direction,
+    ), -INDEX_OFFSET,
+  );
+}
+
+/**
+ * Finds the index for the next uuid which matches the query supplied in the specified direction.
+ *   1. Iterates through each possible position for the query in the UUID string
+ *   2. Solves each possibility
+ *   3. Returns the solution closest to startIndex in direction
+ */
+function findNextIndex(query, startIndex, direction) {
+  query = query.toLowerCase();
+
+  const padLength = uuidFromIndex(0n).length - query.length;
+  const validPatterns = Array(padLength + 1).fill(0)
+    .map((_, index) => '*'.repeat(index) + query + '*'.repeat(padLength - index))
+    .map(maskHyphens)
+    .filter(patternIsValid);
+
+  if (validPatterns.length === 0) return undefined;
+
+  if (query.length <= 3) {
+    return nextIndexBruteForce(query, startIndex, direction);
+  }
+
+  return findBestSolution(validPatterns.map((pattern) => {
+    return nextIndexForPattern(patternToBits(pattern), startIndex, direction);
+  }), startIndex, direction);
+}
+
+const index = findNextIndex('abcd', 0n, 1n);
+console.log(index, uuidFromIndex(index));
+// 7263n 'bf7be111-ee50-49db-bb8f-2c83abcdbacc'
+
+
+
+
+
 // for demonstration purposes only
 export function intToUUID(n) {
   if (typeof n !== "bigint") {

--- a/lib/uuidTools.js
+++ b/lib/uuidTools.js
@@ -3,7 +3,12 @@ import randomBytesSeed from '@csquare/random-bytes-seed';
 const UUID_ENTROPY = 122n;
 const UUID_COUNT = 1n << UUID_ENTROPY;
 const BIT_MASK_FULL = UUID_COUNT - 1n;
-const INDEX_OFFSET = 1237834238432n; // Random offest
+const INDEX_OFFSET = 1237834238432n; // Random offset
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[4*][0-9a-f]{3}-[89ab*][0-9a-f]{3}-[0-9a-f]{12}$/;
+const UUID_PATTERN_REGEX = /^[0-9a-f*]{8}-[0-9a-f*]{4}-[4*][0-9a-f*]{3}-[89ab*][0-9a-f*]{3}-[0-9a-f*]{12}$/;
+const DELIMITER_INDEXES = [8, 13, 18, 23];
+const DISALLOWED_QUERY_CHARACTER = /[^a-f0-9-]/;
 
 /** Inverts a matrix, assumes it is invertible */
 function invertMatrix(matrix) {
@@ -145,14 +150,23 @@ function uuidToString(value) {
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }
 
+function uuidValueFromString(uuid) {
+  if (!uuid.match(UUID_REGEX)) {
+    throw new Error('Invalid UUID')
+  }
+
+  const value = BigInt('0x' + uuid.replace(/-/g, ''));
+
+  return (
+    (value & ((1n << 62n) - 1n)) |
+    (((value >> 64n) & ((1n << 12n) - 1n)) << 62n) |
+    ((value >> 80n) << 74n)
+  );
+}
+
 /** Offets an index to avoid the first UUID being 0 */
 function offsetIndex(index, offset) {
   return modulo(index + offset, UUID_COUNT);
-}
-
-/** Returns a UUID string from an index */
-function uuidFromIndex(index) {
-  return uuidToString(encrypt(offsetIndex(index, INDEX_OFFSET), ENCRYPT_MATRIX));
 }
 
 /** Compares two values and returns if they are greater/lesser/equal */
@@ -182,7 +196,7 @@ function maskIndex(index, bit) {
 function nextIndexBruteForce(query, index, direction) {
   while(true) {
     index = modulo(index + direction, UUID_COUNT)
-    if (uuidFromIndex(index).includes(query))  {
+    if (indexToUUID(index).includes(query))  {
       return index
     }
   }
@@ -203,14 +217,10 @@ function hexToBits(character) {
   return bits;
 }
 
-const HEX = '[0-9a-f*]';
-const UUID_REGEX = new RegExp(`^${HEX}{8}-${HEX}{4}-[4*]${HEX}{3}-[89ab*]${HEX}{3}-${HEX}{12}$`);
-const DELIMITER_INDEXES = [8, 13, 18, 23];
-
 /** Returns if a UUID pattern is valid */
 function patternIsValid(pattern) {
   if (pattern.length !== 36) return false;
-  return Boolean(pattern.match(UUID_REGEX));
+  return Boolean(pattern.match(UUID_PATTERN_REGEX));
 }
 
 /** Replace a character in a string */
@@ -219,7 +229,7 @@ function replaceCharacter(value, index, character) {
 }
 
 /** Returns a UUID pattern with asterisks replaced with hyphens appropriately */
-function maskHyphens(pattern) {
+function insertHyphens(pattern) {
   DELIMITER_INDEXES.forEach((index) => {
     if (pattern[index] === '*') pattern = replaceCharacter(pattern, index, '-');
   })
@@ -404,13 +414,15 @@ function nextIndexForPattern(patternBits, startIndex, direction) {
  *   2. Solves each possibility
  *   3. Returns the solution closest to startIndex in direction
  */
-function findNextIndex(query, startIndex, direction) {
+export function findNextIndex(query, startIndex, direction) {
   query = query.toLowerCase();
 
-  const padLength = uuidFromIndex(0n).length - query.length;
+  if (query.match(DISALLOWED_QUERY_CHARACTER)) return undefined;
+
+  const padLength = indexToUUID(0n).length - query.length;
   const validPatterns = Array(padLength + 1).fill(0)
     .map((_, index) => '*'.repeat(index) + query + '*'.repeat(padLength - index))
-    .map(maskHyphens)
+    .map(insertHyphens)
     .filter(patternIsValid);
 
   if (validPatterns.length === 0) return undefined;
@@ -424,13 +436,19 @@ function findNextIndex(query, startIndex, direction) {
   }), startIndex, direction);
 }
 
-const index = findNextIndex('abcd', 0n, 1n);
-console.log(index, uuidFromIndex(index));
+// const index = findNextIndex('abcd', 0n, 1n);
+// console.log(index, indexToUUID(index));
 // 7263n 'bf7be111-ee50-49db-bb8f-2c83abcdbacc'
 
+/** Returns a UUID string from an index */
+export function indexToUUID(index) {
+  return uuidToString(encrypt(offsetIndex(index, INDEX_OFFSET), ENCRYPT_MATRIX));
+}
 
-
-
+/** Returns a UUID index from a string */
+export function uuidToIndex(uuid) {
+  return offsetIndex(encrypt(uuidValueFromString(uuid), INVERSE_ENCRYPT_MATRIX), -INDEX_OFFSET);
+}
 
 // for demonstration purposes only
 export function intToUUID(n) {
@@ -465,146 +483,4 @@ export function intToUUID(n) {
   const p5 = node.toString(16).padStart(12, "0");
 
   return `${p1}-${p2}-${p3}-${p4}-${p5}`;
-}
-
-const ROUND_CONSTANTS = [
-  BigInt("0x47f5417d6b82b5d1"),
-  BigInt("0x90a7c5fe8c345af2"),
-  BigInt("0xd8796c3b2a1e4f8d"),
-  BigInt("0x6f4a3c8e7d5b9102"),
-  BigInt("0xb3f8c7d6e5a49201"),
-  BigInt("0x2d9e8b7c6f5a3d4e"),
-  BigInt("0xa1b2c3d4e5f6789a"),
-  BigInt("0x123456789abcdef0"),
-];
-
-// N has one bit from left and one from right (2 for variant)
-// bits from left          bits from right
-// ------------------------------------
-// |                  |                |
-// xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx
-
-// just using 4 rounds seems to produce a good enough distribution to appear
-// random
-const ROUNDS_USED = 4;
-
-export function indexToUUID(index) {
-  if (index >= BigInt(2) ** BigInt(122)) {
-    throw new Error("Index out of range - must be less than 2^122");
-  }
-  if (index < 0n) {
-    // console.log(`ERROR! index: ${index}`);
-  }
-
-  let left = BigInt(index) >> BigInt(61);
-  let right = BigInt(index) & ((BigInt(1) << BigInt(61)) - BigInt(1));
-
-  for (let round = 0; round < ROUNDS_USED; round++) {
-    const mixed = feistelRound(right, round);
-    const newRight = left ^ (mixed & ((BigInt(1) << BigInt(61)) - BigInt(1))); // Ensure 61-bit result
-    left = right;
-    right = newRight;
-  }
-
-  let result = BigInt(0);
-  // first 48 bits from the left
-  // left: 13 bits remaining; right: 61 bits remaining; total: 48 bits used
-  result |= (left >> BigInt(13)) << BigInt(80);
-  // 4 bits for version
-  // left: 13 bits remaining; right: 61 bits remaining; total: 52 bits used
-  result |= BigInt(4) << BigInt(76);
-  // next 12 bits from left
-  // left: 1 bit remaining; right: 61 bits remaining; total: 64 bits used
-  const next12BitsFromLeft =
-    (left >> BigInt(1)) & ((BigInt(1) << BigInt(12)) - BigInt(1));
-  result |= next12BitsFromLeft << BigInt(64);
-  // 2 bits for variant
-  // left: 1 bit remaining; right: 61 bits remaining; total: 66 bits used
-  result |= BigInt(2) << BigInt(62);
-  // 1 bit remaining from the left!
-  // left: 0 bits remaining; right: 61 bits remaining; total: 67 bits used
-  const lastBitFromLeft = left & BigInt(1);
-  // good to use all the bits from the right
-  result |= lastBitFromLeft << BigInt(61);
-  result |= right;
-
-  let hex = result.toString(16).padStart(32, "0");
-  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
-}
-
-function feistelRound(block, round) {
-  // Mix using rotations, XORs, and addition, maintaining 61-bit blocks
-  let mixed = block;
-  mixed ^= ROUND_CONSTANTS[round] & ((BigInt(1) << BigInt(61)) - BigInt(1));
-  mixed =
-    ((mixed << BigInt(7)) | (mixed >> BigInt(54))) &
-    ((BigInt(1) << BigInt(61)) - BigInt(1));
-  mixed =
-    (mixed * BigInt("0x6c8e944d1f5aa3b7")) &
-    ((BigInt(1) << BigInt(61)) - BigInt(1));
-  mixed =
-    ((mixed << BigInt(13)) | (mixed >> BigInt(48))) &
-    ((BigInt(1) << BigInt(61)) - BigInt(1));
-
-  return mixed;
-}
-
-function splitUUID(uuid) {
-  const hex = uuid.replace(/-/g, "");
-  const value = BigInt("0x" + hex);
-
-  let left = BigInt(0);
-  let right = BigInt(0);
-
-  //                    (includes LSB of N)
-  //                         grab these
-  //                    |               |
-  // xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx
-  // Final bit (0) came from after variant bit
-  right = value & ((BigInt(1) << BigInt(61)) - BigInt(1));
-
-  //  grab these
-  // |           |
-  // xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx
-  // Highest 48 bits (60-13) came from first shift
-  left |= (value >> BigInt(80)) << BigInt(13);
-
-  //             grab these
-  //                | |
-  // xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx
-  // Next 12 bits (12-1) came from middle section
-  const mid12Bits =
-    (value >> BigInt(64)) & ((BigInt(1) << BigInt(12)) - BigInt(1));
-  left |= mid12Bits << BigInt(1);
-
-  //                grab bit 1 of N (0 is for right, 2-3 for variant)
-  //                    |
-  // xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx
-  // Final bit (0) came from after variant bit
-  const lastBit = (value >> BigInt(61)) & BigInt(1);
-  left |= lastBit;
-
-  return { left, right };
-}
-
-export function uuidToIndex(uuid) {
-  // First split the UUID back into left and right values
-  const { left, right } = splitUUID(uuid);
-
-  // Now reverse the Feistel network
-  let current_left = left;
-  let current_right = right;
-
-  // Run rounds in reverse
-  for (let round = ROUNDS_USED - 1; round >= 0; round--) {
-    const prev_right = current_left;
-    const mixed = feistelRound(prev_right, round);
-    const prev_left =
-      current_right ^ (mixed & ((BigInt(1) << BigInt(61)) - BigInt(1)));
-    current_left = prev_left;
-    current_right = prev_right;
-  }
-
-  // Reconstruct the original index
-  return (current_left << BigInt(61)) | current_right;
 }

--- a/lib/uuidTools.js
+++ b/lib/uuidTools.js
@@ -10,6 +10,21 @@ const UUID_PATTERN_REGEX = /^[0-9a-f*]{8}-[0-9a-f*]{4}-[4*][0-9a-f*]{3}-[89ab*][
 const DELIMITER_INDEXES = [8, 13, 18, 23];
 const DISALLOWED_QUERY_CHARACTER = /[^a-f0-9-]/;
 
+/** Wrapper for seeded random bytes */
+class RandomBytes {
+  constructor(seed) {
+    this.seed = seed
+  }
+  next(bytes) {
+    const output = randomBytesSeed(16, this.seed);
+    this.seed = output;
+    return output;
+  }
+}
+
+const ENCRYPT_MATRIX = randomInvertibleMatrix(122, new RandomBytes('42'));
+const INVERSE_ENCRYPT_MATRIX = invertMatrix(ENCRYPT_MATRIX);
+
 /** Inverts a matrix, assumes it is invertible */
 function invertMatrix(matrix) {
   const identity = Array(matrix.length).fill(0).map((_, i) => 1n << BigInt(i))
@@ -78,18 +93,6 @@ function isFullRank(matrix) {
   return rank(matrix) === matrix.length;
 }
 
-/** Wrapper for seeded random bytes */
-class RandomBytes {
-  constructor(seed) {
-    this.seed = seed
-  }
-  next(bytes) {
-    const output = randomBytesSeed(16, this.seed);
-    this.seed = output;
-    return output;
-  }
-}
-
 /** Returns a BigInt constructed from a Buffer of bytes */
 function bytesToBigInt(bytes) {
   return BigInt(
@@ -112,9 +115,6 @@ function randomInvertibleMatrix(size, randomGenerator) {
     if (isFullRank(matrix)) return matrix
   }
 }
-
-const ENCRYPT_MATRIX = randomInvertibleMatrix(122, new RandomBytes('42'));
-const INVERSE_ENCRYPT_MATRIX = invertMatrix(ENCRYPT_MATRIX);
 
 /** Returns the count of the non-zero bits in a BigInt */
 function countBits(value) {

--- a/lib/uuidTools.js
+++ b/lib/uuidTools.js
@@ -436,10 +436,6 @@ export function findNextIndex(query, startIndex, direction) {
   }), startIndex, direction);
 }
 
-// const index = findNextIndex('abcd', 0n, 1n);
-// console.log(index, indexToUUID(index));
-// 7263n 'bf7be111-ee50-49db-bb8f-2c83abcdbacc'
-
 /** Returns a UUID string from an index */
 export function indexToUUID(index) {
   return uuidToString(encrypt(offsetIndex(index, INDEX_OFFSET), ENCRYPT_MATRIX));

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@csquare/random-bytes-seed": "^0.1.3",
         "eslint": "^8.57.1",
         "eslint-config-react-app": "^7.0.1",
         "new-component": "^5.0.3",
@@ -21,6 +22,14 @@
         "react-feather": "^2.0.10",
         "rimraf": "^6.0.1",
         "styled-components": "^6.1.13"
+      },
+      "devDependencies": {
+        "buffer": "^6.0.3",
+        "crypto-browserify": "^3.12.1",
+        "events": "^3.3.0",
+        "stream-browserify": "^3.0.0",
+        "string_decoder": "^1.3.0",
+        "vm-browserify": "^1.1.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1758,6 +1767,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@csquare/random-bytes-seed": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@csquare/random-bytes-seed/-/random-bytes-seed-0.1.3.tgz",
+      "integrity": "sha512-gQ2eS7g/qklEUnJlU8PwoDW/VjUwN7Wt1/8dIl9gLscv44cmE9qovZn2opEVHMcbyr6idTMzXhxC8gXwKj0kgA==",
+      "license": "MIT"
     },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.2.2",
@@ -4341,6 +4356,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asn1.js": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/asn1.js/node_modules/bn.js": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -4467,6 +4501,34 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -4485,6 +4547,90 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/browserify-cipher": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      }
+    },
+    "node_modules/browserify-des": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/browserify-rsa": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
+      "integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^5.2.1",
+        "randombytes": "^2.1.0",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/browserify-sign": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.3.tgz",
+      "integrity": "sha512-JWCZW6SKhfhjJxO8Tyiiy+XYB7cqd2S5/+WeYHsKdNKFlCBhKbblba1A/HN/90YwtxKc8tCErjffZl++UNmGiw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "bn.js": "^5.2.1",
+        "browserify-rsa": "^4.1.0",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.5.5",
+        "hash-base": "~3.0",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.7",
+        "readable-stream": "^2.3.8",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.12"
       }
     },
     "node_modules/browserslist": {
@@ -4517,6 +4663,38 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/call-bind": {
       "version": "1.0.7",
@@ -4594,6 +4772,20 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/cipher-base": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
+      "integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
@@ -4653,6 +4845,13 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -4668,6 +4867,53 @@
         "node": ">=10"
       }
     },
+    "node_modules/create-ecdh": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.5.3"
+      }
+    },
+    "node_modules/create-ecdh/node_modules/bn.js": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "node_modules/create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4679,6 +4925,33 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypto-browserify": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz",
+      "integrity": "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserify-cipher": "^1.0.1",
+        "browserify-sign": "^4.2.3",
+        "create-ecdh": "^4.0.4",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "diffie-hellman": "^5.0.3",
+        "hash-base": "~3.0.4",
+        "inherits": "^2.0.4",
+        "pbkdf2": "^3.1.2",
+        "public-encrypt": "^4.0.3",
+        "randombytes": "^2.1.0",
+        "randomfill": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/css-color-keywords": {
@@ -4810,6 +5083,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
@@ -4820,6 +5104,25 @@
       "engines": {
         "node": ">=0.10"
       }
+    },
+    "node_modules/diffie-hellman": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      }
+    },
+    "node_modules/diffie-hellman/node_modules/bn.js": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -4928,6 +5231,29 @@
       "version": "1.5.68",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.68.tgz",
       "integrity": "sha512-FgMdJlma0OzUYlbrtZ4AeXjKxKPk6KT8WOP8BjcqxWtlg8qyJQjRzPJzUtUn5GBg1oQ26hFs7HOOHJMYiJRnvQ=="
+    },
+    "node_modules/elliptic": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/elliptic/node_modules/bn.js": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -5538,6 +5864,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5976,6 +6323,31 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hash-base": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.5.tgz",
+      "integrity": "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -5985,6 +6357,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "node_modules/htmlnano": {
@@ -6075,6 +6459,27 @@
         "domutils": "^3.1.0",
         "entities": "^4.5.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -6903,7 +7308,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -6934,6 +7340,18 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -6953,6 +7371,41 @@
       "engines": {
         "node": ">=8.6"
       }
+    },
+    "node_modules/miller-rabin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      },
+      "bin": {
+        "miller-rabin": "bin/miller-rabin"
+      }
+    },
+    "node_modules/miller-rabin/node_modules/bn.js": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -7355,6 +7808,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-asn1": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.7.tgz",
+      "integrity": "sha512-CTM5kuWR3sx9IFamcl5ErfPl6ea/N8IYwiJ+vpeB2g+1iknv7zBl5uPwbMbRVznRVbrNY6lGuDoE5b30grmbqg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asn1.js": "^4.10.1",
+        "browserify-aes": "^1.2.0",
+        "evp_bytestokey": "^1.0.3",
+        "hash-base": "~3.0",
+        "pbkdf2": "^3.1.2",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -7430,6 +7901,23 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pbkdf2": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
+      "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      },
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/picocolors": {
@@ -7640,6 +8128,13 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -7649,6 +8144,28 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/public-encrypt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/public-encrypt/node_modules/bn.js": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -7676,6 +8193,27 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/randomfill": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      }
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -7727,6 +8265,46 @@
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readable-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -7878,6 +8456,17 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -7998,6 +8587,20 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "dev": true,
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      }
+    },
     "node_modules/shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
@@ -8077,6 +8680,42 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stream-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      }
+    },
+    "node_modules/stream-browserify/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-natural-compare": {
@@ -8608,6 +9247,13 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/utility-types": {
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
@@ -8615,6 +9261,13 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/vm-browserify": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+      "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/weak-lru-cache": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "nolen (eieio)",
   "license": "ISC",
   "dependencies": {
+    "@csquare/random-bytes-seed": "^0.1.3",
     "eslint": "^8.57.1",
     "eslint-config-react-app": "^7.0.1",
     "new-component": "^5.0.3",
@@ -27,5 +28,13 @@
     "rimraf": "^6.0.1",
     "styled-components": "^6.1.13"
   },
-  "browserslist": ">0.3%, defaults, supports es6-module"
+  "browserslist": ">0.3%, defaults, supports es6-module",
+  "devDependencies": {
+    "buffer": "^6.0.3",
+    "crypto-browserify": "^3.12.1",
+    "events": "^3.3.0",
+    "stream-browserify": "^3.0.0",
+    "string_decoder": "^1.3.0",
+    "vm-browserify": "^1.1.2"
+  }
 }

--- a/src/components/SearchWidget/SearchWidget.js
+++ b/src/components/SearchWidget/SearchWidget.js
@@ -2,7 +2,6 @@ import React from "react";
 import styled from "styled-components";
 import UnstyledButton from "../UnstyledButton/UnstyledButton";
 import { X, ChevronUp, ChevronDown } from "../Icons/Icons";
-import { uuidToIndex } from "../../../lib/uuidTools";
 import { useUUIDSearch } from "../../../hooks/use-uuid-search";
 import { querySmallScreen, SCROLLBAR_WIDTH } from "../../../lib/constants";
 
@@ -143,30 +142,22 @@ function SearchWidget({
   }, []);
   const shiftIsHeldDown = useShiftIsHeldDown();
 
-  const { searchUUID, currentUUID, nextUUID, previousUUID } = useUUIDSearch({
+  const { searchUUID, currentIndex, nextUUID, previousUUID } = useUUIDSearch({
     displayedUUIDs,
     virtualPosition,
   });
-  const index = React.useMemo(() => {
-    if (currentUUID) {
-      const index = uuidToIndex(currentUUID);
-
-      return index;
-    }
-    return null;
-  }, [currentUUID]);
 
   React.useEffect(() => {
-    if (index) {
-      if (index < 0n) {
+    if (currentIndex) {
+      if (currentIndex < 0n) {
         setVirtualPosition(0n);
-      } else if (index >= MAX_POSITION) {
+      } else if (currentIndex >= MAX_POSITION) {
         setVirtualPosition(MAX_POSITION);
       } else {
-        setVirtualPosition(index);
+        setVirtualPosition(currentIndex);
       }
     }
-  }, [setVirtualPosition, index]);
+  }, [setVirtualPosition, currentIndex]);
 
   React.useEffect(() => {
     window.addEventListener("keydown", (e) => {


### PR DESCRIPTION
This PR adds fully working search, as discussed here: https://github.com/nolenroyalty/every-uuid/issues/12

Replaces the Feistal cipher with a random invertible matrix transformation, which does unfortunately mean the UUID order would have to change to accommodate this feature.

The only major problem with this currently is that I use [@csquare/random-bytes-seed](https://www.npmjs.com/package/@csquare/random-bytes-seed) which is designed to be used server side, requiring a bunch of polyfills and bloating the build size. I'm going to look for an alternative, but I figured I'd show the feature for now.

Minor issue: The search does not currently wrap around from the end to the start if there are results on the final page, because these final results can never be scrolled to. However this is a pre-existing bug masked by the `searchRandomly` fallback. I'll see if I can fix it.

Have not added tests, but happy to!